### PR TITLE
Hard pinning react-native-svg at 4.4.1

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -10,7 +10,7 @@
     "react": "15.4.1",
     "react-native": "0.39.2",
     "react-native-barcode-builder": "0.0.5",
-    "react-native-svg": "^4.4.1"
+    "react-native-svg": "4.4.1"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",


### PR DESCRIPTION
react-native-svg 4.5 and above use react-native 0.40+, which includes a breaking change to the format of native files. Because we've got react-native 0.39.2 pinned, this ensures the example works.

I think we should upgrade the library to use react-native-svg 5+ and react-native 0.40+, but this change keeps the example building in the meantime.