### PR TITLE
Handle error when invalid barcode type is given

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,19 @@ export default class Barcode extends PureComponent {
     // Ensure that text is a string
     text = '' + text;
 
-    var encoder = new Encoder(text, options);
+    var encoder;
+
+    try {
+      encoder = new Encoder(text, options);
+    } catch (error) {
+      // If the encoder could not be instantiated, throw error.
+      if (this.props.onError)  {
+        this.props.onError(new Error('Invalid barcode format.'));
+        return;
+      } else {
+        throw new Error('Invalid barcode format.');
+      }
+    }
 
     // If the input is not valid for the encoder, throw error.
     if (!encoder.valid()) {


### PR DESCRIPTION
Currently, if you provide a barcode type that doesn't exist, you get `TypeError: Encoder is not a constructor`. This solves the issue by properly catching the error and throwing our own more descriptive error in its place.