### PR TITLE
Add a way to find the required view width for the barcode

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,19 @@ export default class Barcode extends PureComponent {
     this.update();
   }
 
+  // Calculate and provide the width required by a render of the barcode for the current input.
+  renderWidth() {
+    // TODO: store work done so that update() doesn't have to repeat.
+    const encoder = barcodes[this.props.format];
+    const encoded = this.encode(this.props.value, encoder, this.props);
+
+    if (encoded) {
+      this.state.barCodeWidth = encoded.data.length * this.props.width;
+      return this.state.barCodeWidth;
+    }
+    return 0;
+  }
+
   update() {
     const encoder = barcodes[this.props.format];
     const encoded = this.encode(this.props.value, encoder, this.props);


### PR DESCRIPTION
The ability to find the required width for a render of the barcode data allows figuring out the largest line width that can be used for a particular view, and even determining when the barcode data will not fit in a view. (Finding the view size requires something like https://cmichel.io/how-to-get-the-size-of-a-react-native-view-dynamically). I'm new to JavaScript and React Native, so there might be problems with this code, but it does seem to work.