### PR TITLE
Throw error if the value prop is not a non-empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,9 +129,8 @@ export default class Barcode extends PureComponent {
       if (this.props.onError) {
         this.props.onError(new Error('Barcode value must be a non-empty string'));
         return;
-      } else {
-        throw new Error('Barcode value must be a non-empty string');
       }
+      throw new Error('Barcode value must be a non-empty string');
     }
 
     var encoder;
@@ -143,9 +142,8 @@ export default class Barcode extends PureComponent {
       if (this.props.onError)  {
         this.props.onError(new Error('Invalid barcode format.'));
         return;
-      } else {
-        throw new Error('Invalid barcode format.');
       }
+      throw new Error('Invalid barcode format.');
     }
 
     // If the input is not valid for the encoder, throw error.
@@ -153,9 +151,8 @@ export default class Barcode extends PureComponent {
       if (this.props.onError) {
         this.props.onError(new Error('Invalid barcode for selected format.'));
         return;
-      } else {
-        throw new Error('Invalid barcode for selected format.');
       }
+      throw new Error('Invalid barcode for selected format.');
     }
 
     // Make a request for the binary data (and other infromation) that should be rendered

--- a/index.js
+++ b/index.js
@@ -124,8 +124,15 @@ export default class Barcode extends PureComponent {
 
   // encode() handles the Encoder call and builds the binary string to be rendered
   encode(text, Encoder, options) {
-    // Ensure that text is a string
-    text = '' + text;
+    // If text is not a non-empty string, throw error.
+    if (typeof text !== "string" || text.length === 0) {
+      if (this.props.onError) {
+        this.props.onError(new Error('Barcode value must be a non-empty string'));
+        return;
+      } else {
+        throw new Error('Barcode value must be a non-empty string');
+      }
+    }
 
     var encoder;
 


### PR DESCRIPTION
# Context:
In the documentation, the `value` prop is marked as a `required` prop. But when users forget to provide this prop, it does not raise any exceptions or show any warnings. When generating barcode for my app, I used the `text` prop instead of `value` prop and the barcode is showing fine. The value of the barcode when scanning is `undefined`. I was so dumb that I did not check it before releasing the app, which caused my users could not use the barcode. 
# Summary:
This PR is to throw an error if the value prop is not a non-empty string. As value prop is a `required` prop, it should raise an exception if the value is blank.
# Screenshots
<img src="https://user-images.githubusercontent.com/4929170/61198673-36592e00-a705-11e9-9c6e-cf42efbe036f.png" width="270" />|
:-:|
When no value, no onError

<img src="https://user-images.githubusercontent.com/4929170/61198684-440eb380-a705-11e9-87ae-aa36de6258cf.png" width="270" />|<img width="270" alt="Screen Shot 2019-07-15 at 11 38 44 AM" src="https://user-images.githubusercontent.com/4929170/61198703-57218380-a705-11e9-95c9-78243bf01bf6.png">
:-:|:-:
When no value, onError|Console

<img src="https://user-images.githubusercontent.com/4929170/61198696-4e30b200-a705-11e9-9a87-15cebbf602f6.png" width="270" />|
:-:|
When value prop is present|
