### PR TITLE
Use community ART implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import barcodes from 'jsbarcode/src/barcodes';
 
-import {Surface, Shape} from '@react-native-community/art';
+import { Surface, Shape } from '@react-native-community/art';
 
 export default class Barcode extends PureComponent {
   static propTypes = {
@@ -168,8 +168,8 @@ export default class Barcode extends PureComponent {
     };
     return (
       <View style={[styles.svgContainer, backgroundStyle]}>
-        <Surface height={this.props.height} width={this.state.barCodeWidth}>
-          <Shape d={this.state.bars} fill={this.props.lineColor} />
+        <Surface height={this.props.height} width={this.state.barCodeWidth} visible={true}>
+          <Shape d={this.state.bars} fill={this.props.lineColor} visible={true} />
         </Surface>
         { typeof (this.props.text) !== 'undefined' &&
           <Text style={{color: this.props.textColor, width: this.state.barCodeWidth, textAlign: 'center'}} >{this.props.text}</Text>

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 import React, { PureComponent } from 'react';
-import { View, StyleSheet, ART, Text } from 'react-native';
+import { View, StyleSheet, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
 import barcodes from 'jsbarcode/src/barcodes';
 
-const { Surface, Shape } = ART;
+import {Surface, Shape} from '@react-native-community/art';
 
 export default class Barcode extends PureComponent {
   static propTypes = {

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ export default class Barcode extends PureComponent {
         <Surface height={this.props.height} width={this.state.barCodeWidth}>
           <Shape d={this.state.bars} fill={this.props.lineColor} />
         </Surface>
-        { typeof(this.props.text) != 'undefined' &&
+        { typeof (this.props.text) !== 'undefined' &&
           <Text style={{color: this.props.textColor, width: this.state.barCodeWidth, textAlign: 'center'}} >{this.props.text}</Text>
         }
       </View>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "WonSikin <fnghwsj@gmail.com>",
   "dependencies": {
     "jsbarcode": "^3.8.0",
-    "@react-native-community/art": "^1.0.1",
+    "@react-native-community/art": "^1.0.1"
   },
   "peerDependencies": {
     "prop-types": "^15.5.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "keywords": ["react-native", "barcode"],
   "author": "WonSikin <fnghwsj@gmail.com>",
   "dependencies": {
-    "jsbarcode": "^3.8.0"
+    "jsbarcode": "^3.8.0",
+    "@react-native-community/art": "^1.0.1",
   },
   "peerDependencies": {
     "prop-types": "^15.5.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "scripts": {
     "lint": "eslint ./"
   },
-  "keywords": ["react-native", "barcode"],
+  "keywords": [
+    "react-native",
+    "barcode"
+  ],
   "author": "WonSikin <fnghwsj@gmail.com>",
   "dependencies": {
     "jsbarcode": "^3.8.0",


### PR DESCRIPTION
Importing ART from `react-native` is deprecated, and will soon be removed.
This PR imports it from it's new location `@react-native-community/art`.