### PR TITLE
Changing library from ART to react-native-svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ React Native component to generate barcodes. Uses [JsBarcode](https://github.com
 
 #### Step 1
 
-Link React ART; open the Xcode project, and drag `ART.xcodeproj` from `node_modules/react-native/Libraries/ART/` into the `Libraries` group in Xcode.
-Then select the root project and select "Build Phases" from the center view. There will be a section called "Link Binary With Libraries", expand it, press the + and select `libART.a`.
+~~Link React ART; open the Xcode project, and drag `ART.xcodeproj` from `node_modules/react-native/Libraries/ART/` into the `Libraries` group in Xcode.
+Then select the root project and select "Build Phases" from the center view. There will be a section called "Link Binary With Libraries", expand it, press the + and select `libART.a`.~~
+
+This library uses [@react-native-community/react-native-svg](https://github.com/react-native-community/react-native-svg) instead of [@react-native-community/art](https://github.com/react-native-community/art)
 
 #### Step 2
 
 Install `react-native-barcode-builder`:
 
     npm install react-native-barcode-builder --save
-
 
 #### Step 3
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ React Native component to generate barcodes. Uses [JsBarcode](https://github.com
 
 This library uses [@react-native-community/react-native-svg](https://github.com/react-native-community/react-native-svg) instead of [@react-native-community/art](https://github.com/react-native-community/art)
 
-#### Step 1
+### Step 1
 
 Install `react-native-barcode-builder`:
 
     npm install react-native-barcode-builder --save
 
-or 
+or
 
     yarn add react-native-barcode-builder
   
-#### Step 2
+### Step 2
 
 Start using the component
 

--- a/README.md
+++ b/README.md
@@ -5,20 +5,19 @@ React Native component to generate barcodes. Uses [JsBarcode](https://github.com
 
 ## Getting started
 
-#### Step 1
-
-~~Link React ART; open the Xcode project, and drag `ART.xcodeproj` from `node_modules/react-native/Libraries/ART/` into the `Libraries` group in Xcode.
-Then select the root project and select "Build Phases" from the center view. There will be a section called "Link Binary With Libraries", expand it, press the + and select `libART.a`.~~
-
 This library uses [@react-native-community/react-native-svg](https://github.com/react-native-community/react-native-svg) instead of [@react-native-community/art](https://github.com/react-native-community/art)
 
-#### Step 2
+#### Step 1
 
 Install `react-native-barcode-builder`:
 
     npm install react-native-barcode-builder --save
 
-#### Step 3
+or 
+
+    yarn add react-native-barcode-builder
+  
+#### Step 2
 
 Start using the component
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 import React, { PureComponent } from 'react';
-import { View, StyleSheet, ART, Text } from 'react-native';
+import { View, StyleSheet, Text } from 'react-native';
 import PropTypes from 'prop-types';
+import Svg, {
+  Path,
+} from 'react-native-svg';
 
 import barcodes from 'jsbarcode/src/barcodes';
-
-const { Surface, Shape } = ART;
 
 export default class Barcode extends PureComponent {
   static propTypes = {
@@ -172,11 +173,18 @@ export default class Barcode extends PureComponent {
     };
     return (
       <View style={[styles.svgContainer, backgroundStyle]}>
-        <Surface height={this.props.height} width={this.state.barCodeWidth}>
-          <Shape d={this.state.bars} fill={this.props.lineColor} />
-        </Surface>
-        { typeof(this.props.text) != 'undefined' &&
-          <Text style={{color: this.props.textColor, width: this.state.barCodeWidth, textAlign: 'center'}} >{this.props.text}</Text>
+        <Svg
+          height={this.props.height}
+          width={this.state.barCodeWidth}
+          fill={this.props.lineColor}>
+          <Path
+            d={this.state.bars.join(' ')}
+          />
+        </Svg>
+        {typeof (this.props.text) != 'undefined' &&
+          <Text style={{ color: this.props.textColor, width: this.state.barCodeWidth, textAlign: 'center' }} >
+            {this.props.text}
+          </Text>
         }
       </View>
     );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "keywords": ["react-native", "barcode"],
   "author": "WonSikin <fnghwsj@gmail.com>",
   "dependencies": {
-    "jsbarcode": "^3.8.0"
+    "jsbarcode": "^3.8.0",
+    "react-native-svg": "^9.13.3"
   },
   "peerDependencies": {
     "prop-types": "^15.5.0"


### PR DESCRIPTION

This change removes ART and adds react-native-svg as the drawing library for producing the barcode. This change is to support the deprecation of ART from the ReactNative libraries. The react community ART library is not linked in Expo v36 projects. SVG is the preferred method. This change is linked to issue #49 https://github.com/wonsikin/react-native-barcode-builder/issues/49

There are no tests for this changes. Changes will need to be made to the readme first. 